### PR TITLE
operator improvements + fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ As Odoo changed the attrs to (no more attrs) in v17, I created this little scrip
 
 Simply install with 
 ```shell
-pip install beautifulsoup4 lxml
+pip install lxml
 ```
 OR
 ```shell

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -17,8 +17,11 @@ all_xml_files = get_files_recursive(root_dir)
 
 
 def normalize_domain(domain):
-    """Normalize Domain, taken from odoo/osv/expression.py -> just the part so that & operators are added where needed.
-        After that, we can use a part of the def parse() from the same file to manage parenthesis for and/or"""
+    """
+    Normalize Domain, taken from odoo/osv/expression.py -> just the part so that & operators are added where needed.
+    After that, we can use a part of the def parse() from the same file to manage parenthesis for and/or
+    :rtype: list[str|tuple]
+    """
     if len(domain) == 1:
         return domain
     result = []
@@ -38,6 +41,10 @@ def normalize_domain(domain):
 
 
 def stringify_leaf(leaf):
+    """
+    :param tuple leaf:
+    :rtype: str
+    """
     stringify = ''
     switcher = False
     case_insensitive = False
@@ -95,6 +102,10 @@ def stringify_leaf(leaf):
 
 
 def stringify_attr(stack):
+    """
+    :param bool|str|int|list stack:
+    :rtype: bool|str|int
+    """
     if stack in (True, False, 'True', 'False', 1, 0, '1', '0'):
         return stack
     last_parenthesis_index = max(index for index, item in enumerate(stack[::-1]) if item not in ('|', '!'))
@@ -126,6 +137,10 @@ def stringify_attr(stack):
 
 
 def get_new_attrs(attrs):
+    """
+    :param str attrs:
+    :rtype: dict[bool|str|int]
+    """
     new_attrs = {}
     # Temporarily replace dynamic variables (field reference, context value, %()d) in leafs by strings prefixed with '__dynamic_variable__.'
     # This way the evaluation won't fail on these strings and we can later identify them to convert back to  their original values

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 xml_4indent_formatter = formatter.XMLFormatter(indent=4)
 NEW_ATTRS = {'required', 'invisible', 'readonly', 'column_invisible'}
-percent_d_regex = re.compile(r"%\('?\"?[\w\.\d_]+'?\"?\)d")
 
 
 def get_files_recursive(path):
@@ -170,12 +169,10 @@ for xml_file in all_xml_files:
             f.close()
             if not 'attrs' in contents and not 'states' in contents:
                 continue
-            counter_for_percent_d_replace = 1
             percent_d_results = {}
-            for percent_d in percent_d_regex.findall(contents):
-                contents = contents.replace(percent_d, "'REPLACEME%s'" % counter_for_percent_d_replace)
-                percent_d_results[counter_for_percent_d_replace] = percent_d
-                counter_for_percent_d_replace += 1
+            for index, percent_d in enumerate(re.findall(r"%\([\w\.]+\)d", contents), 1):
+                contents = contents.replace(percent_d, "'REPLACEME%s'" % index)
+                percent_d_results[index] = percent_d
             soup = bs(contents, 'xml')
             tags_with_attrs = soup.select('[attrs]')
             attribute_tags_name_attrs = soup.select('attribute[name="attrs"]')

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -49,8 +49,16 @@ def stringify_leaf(leaf):
     # Take care of right operand, don't add quotes if it's list/tuple/set/boolean/number, check if we have a true/false/1/0 string tho.
     right_operand = leaf[2]
 
+    # Handle '=?'
+    if operator == '=?':
+        if type(right_operand) == str:
+            if re.search('^__field_or_context__\.', right_operand):
+                right_operand = re.sub('^__field_or_context__\.(.*)', '\\1', right_operand)
+            else:
+                right_operand = f"'{right_operand}'"
+        return f"({right_operand} in [None, False] or {left_operand} == {right_operand})"
     # Handle '='
-    if operator == '=':
+    elif operator == '=':
         if right_operand in (False, []):  # Check for False or empty list
             return f"not {left_operand}"
         elif right_operand == True:  # Check for True using '==' comparison so only boolean values can evaluate to True

--- a/testfile.xml
+++ b/testfile.xml
@@ -3,20 +3,20 @@
     <form>
         <xpath expr="//">
             <!-- readonly should give: -->
-            <!-- (field1 == 'yes' and field2 == 'yes') or (field3 == 'yes' or field4 == 'yes') or field5 == 'yes' and field6 == 'yes' -->
-            <field attrs="{'invisible': True, 'readonly': ['|', '|', '&amp;', ('field1', '=', 'yes'), ('field2', '=', 'yes'), '|', ('field3', '=', 'yes'), ('field4', '=', 'yes'), ('field5', '=', 'yes'), ('field6', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c'])], 'column_invisible': 0}" name="name"/>
+            <!-- (field1 == 'yes' and field2 != parent.some_field) or (field3 == uid or 'some-string'.lower() in field4.lower()) or 'yes' not in field5 and field6 == 'yes' -->
+            <field string="foo" attrs="{'invisible': True, 'readonly': ['|', '|', '&amp;', ('field1', '=', 'yes'), ('field2', '!=', parent.some_field), '|', ('field3', '=', uid), ('field4', '=ilike', 'some-string'), ('field5', 'not like', 'yes'), ('field6', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c']), ('otherfield', '=?', some_field)], 'column_invisible': 0}" name="name"/>
         </xpath>
         <xpath expr="//." position="attributes">
             <attribute name="attrs">{'invisible': True, 'readonly': [('otherfield', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c'])], 'column_invisible': 0}</attribute>
         </xpath>
         <xpath expr="//field" position="attributes">
-            <attribute name="attrs">{'invisible': [('some', '=', False), ('other', '!=', False)], 'readonly': [('some', '=', True), ('other', '!=', True)], 'required': [('field', '=', []), ('other', '!=', [])], 'column_invisible': 0}</attribute>
+            <attribute name="attrs">{'invisible': [('some', '=', False), ('other', '!=', False)], 'readonly': [('some', '=', True), ('other', '!=', True)], 'required': [('some', '=', []), ('other', '!=', [])], 'column_invisible': [('some', '=', 'str'), ('other', '!=', 'str')]}</attribute>
         </xpath>
         <xpath expr="//test_states_simple_case">
             <field states="draft,done"/>
         </xpath>
         <xpath expr="//test_states_attrs_simple_case">
-            <attribute name="states">draft</attribute>
+            <attribute name="states">draft,done</attribute>
         </xpath>
         <xpath expr="//test_states_with_invisible_existing">
             <field states="draft,done" attrs="{'invisible': [('testfield', '=', 'hello world')]}"/>
@@ -24,7 +24,7 @@
         <xpath expr="//test_states_attrs_with_invisible_existing" position="attributes">
             <attribute name="attrs">{
             'invisible': [
-                '|', 
+                '|',
                 '|',
                 '&amp;',
                 ('test1', 'in', [1, 2, 3]),
@@ -41,7 +41,7 @@
         </xpath>
         <field name="test" attrs="{
             'invisible': [
-                '|', 
+                '|',
                 '|',
                 '&amp;',
                 ('test1', 'in', [1, 2, 3]),

--- a/testfile.xml
+++ b/testfile.xml
@@ -11,6 +11,7 @@
         </xpath>
         <xpath expr="//field" position="attributes">
             <attribute name="attrs">{'invisible': [('some', '=', False), ('other', '!=', False)], 'readonly': [('some', '=', True), ('other', '!=', True)], 'required': [('some', '=', []), ('other', '!=', [])], 'column_invisible': [('some', '=', 'str'), ('other', '!=', 'str')]}</attribute>
+            <attribute name="indent_test"/>
         </xpath>
         <xpath expr="//test_states_simple_case">
             <field states="draft,done"/>
@@ -36,6 +37,7 @@
             <attribute name="states">draft,done</attribute>
         </xpath>
         <xpath expr="//test_states_attrs_with_invisible_existing_and_invisible_single_and">
+            <attribute name="indent_test"/>
             <attribute name="attrs">{'invisible': ['&amp;', ('test8', '=', True)]}</attribute>
             <attribute name="states">draft,done</attribute>
         </xpath>

--- a/testfile.xml
+++ b/testfile.xml
@@ -30,7 +30,7 @@
                 ('test1', 'in', [1, 2, 3]),
                 ('test2', 'in', [2, 3, 4]),
                 ('test3', '=', 'hello'),
-                ('test4', 'in', [%('testmodule.test_xml_id')d, %('testmodule.test_xml_id_2')d])
+                ('test4', 'in', [%(testmodule.test_xml_id)d, %(testmodule.test_xml_id_2)d])
             ]
             }</attribute>
             <attribute name="states">draft,done</attribute>
@@ -47,7 +47,7 @@
                 ('test1', 'in', [1, 2, 3]),
                 ('test2', 'in', [2, 3, 4]),
                 ('test3', '=', 'hello'),
-                ('test4', 'in', [%('testmodule.test_xml_id')d, %(testmodule.test_xml_id_2)d])
+                ('test4', 'in', [%(testmodule.test_xml_id)d, %(testmodule.test_xml_id_2)d])
             ]
         }"/>
         <!-- Case given by odoo, single '|' with states - can cause bug while should be accepted -->


### PR DESCRIPTION
- Adds support for **ilike** and **=?** operators
- Adds support for field and context values (which couldn't be evaluated before)
- Fixes conversion of leaves with string values in combination with the **=** or **!=** operator
- Ensures the order of the existing attributes isn't changed after conversion
  - with BeautifulSoup it was not possible to add attributes in a specific order and attributes would be re-ordered after conversion, making history in version control systems harder to read and more importantly, made it harder to compare the changed files and check for faulty conversions
  - using etree instead the order of the attributes is now kept the same, and additionally, the new attributes are added in the same position as the old attrs and states attributes