### PR TITLE
Improvements patch #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Odoo Attrs replacer
-As Odoo changed the attrs to (no more attrs) in v17, I created this little script to help you replace all attrs in your XML files with corresponding attributes in the XML directly.
+As Odoo changed the attrs to (no more attrs) in v17, as well as combining states into invisible attributes, I created this little script to help you replace all attrs and states in your XML files with corresponding attributes in the XML directly.
 
 ## Dependencies
 
@@ -26,6 +26,11 @@ The script will ask you, for each file, if you want to replace all `attrs=` and 
 
 Unless you chose in the beginning 'y' for auto-replace (don't ask for each file)
 
+## Important before running the script
+
+In Odoo 17 the invisible attributes on fields in tree views will no longer hide the whole column, only the cell. Hiding the whole column is now done with the column_invisible attribute instead.
+Before running this script, the user should first convert all those invisible attributes on tree fields to column_invisible instead. If this is not done first, those attributes will be combined with the invisible attributes in the attrs dict instead, and thus lost (though it will just be every cell in the column that will be made invisible instead of the column itself, so in essence the values will still be made invisible using the same old conditions).
+
 ## Found a flaw ?
 
 Please open an Issue or make a PR or contact me on LinkedIn (Pierre Locus)
@@ -35,7 +40,7 @@ Please include a **[Minimal Reproducible Example](https://en.wikipedia.org/wiki/
 Thanks in advance!
 
 ## TODO:
-  - [ ] Support missing operators "=?", "child_of", "parent_of" (less used than the others already supported)
+  - [ ] Support missing operators "child_of", "parent_of" (less used than the others already supported)
 
 ## Contributors
 

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -145,6 +145,8 @@ def get_new_attrs(attrs):
     # Temporarily replace dynamic variables (field reference, context value, %()d) in leafs by strings prefixed with '__dynamic_variable__.'
     # This way the evaluation won't fail on these strings and we can later identify them to convert back to  their original values
     escaped_operators = ['=', '!=', '>', '>=', '<', '<=', '=\?', '=like', 'like', 'not like', 'ilike', 'not ilike', '=ilike', 'in', 'not in', 'child_of', 'parent_of']
+    attrs = re.sub("&lt;", "<", attrs)
+    attrs = re.sub("&gt;", ">", attrs)
     attrs = re.sub(f"([\"'](?:{'|'.join(escaped_operators)})[\"']\s*,\s*)(?!False|True)([\w\.]+)(?=\s*[\]\)])", r"\1'__dynamic_variable__.\2'", attrs)
     attrs = re.sub(r"(%\([\w\.]+\)d)", r"'__dynamic_variable__.\1'", attrs)
     attrs = attrs.strip()

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -145,7 +145,7 @@ def get_new_attrs(attrs):
     # Temporarily replace dynamic variables (field reference, context value, %()d) in leafs by strings prefixed with '__dynamic_variable__.'
     # This way the evaluation won't fail on these strings and we can later identify them to convert back to  their original values
     escaped_operators = ['=', '!=', '>', '>=', '<', '<=', '=\?', '=like', 'like', 'not like', 'ilike', 'not ilike', '=ilike', 'in', 'not in', 'child_of', 'parent_of']
-    attrs = re.sub(f"([\"'](?:{'|'.join(escaped_operators)})[\"']\s*,\s*)([\w\.]+)(?=\s*[\]\)])", r"\1'__dynamic_variable__.\2'", attrs)
+    attrs = re.sub(f"([\"'](?:{'|'.join(escaped_operators)})[\"']\s*,\s*)(?!False|True)([\w\.]+)(?=\s*[\]\)])", r"\1'__dynamic_variable__.\2'", attrs)
     attrs = re.sub(r"(%\([\w\.]+\)d)", r"'__dynamic_variable__.\1'", attrs)
     attrs = attrs.strip()
     if re.search("^{.*}$", attrs, re.DOTALL):

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -340,7 +340,7 @@ for xml_file in all_xml_files:
                 attribute_tags_to_remove = []
                 # Insert the new attributes tags in their original position, in their original order in that attrs dict
                 for new_attr, new_attr_value in new_attrs.items():
-                    if separate_attr_tag := get_sibling_attribute_tag_of_type(doc, attribute_tag, new_attr):
+                    if (separate_attr_tag := get_sibling_attribute_tag_of_type(doc, attribute_tag, new_attr)) is not None:
                         attribute_tags_to_remove.append(separate_attr_tag)
                         # Combine attribute if present as a separate attribute as well as in the 'attrs' dict
                         # This is the same behaviour that Odoo 16- uses in this situation
@@ -362,7 +362,7 @@ for xml_file in all_xml_files:
                     new_tag.tail = indent
                     parent_tag.insert(tag_index, new_tag)
                     if new_attr == 'invisible':
-                        if not get_sibling_attribute_tag_of_type(doc, new_tag, 'states'):
+                        if get_sibling_attribute_tag_of_type(doc, new_tag, 'states') is None:
                             # Since before Odoo 17 the states and invisible attributes were separate, if a states attribute was
                             # present in a parent view it would still be combined with the invisible attribute overrides
                             # in inheriting views. Now that they are combined in 17, if in an inheriting view the invisible
@@ -386,7 +386,7 @@ for xml_file in all_xml_files:
                     # Only field tags can use readonly, required and column_invisible attributes
                     potentially_missing_attrs = ['invisible']
                 for missing_attr in potentially_missing_attrs:
-                    if missing_attr not in new_attrs and not get_sibling_attribute_tag_of_type(doc, attribute_tag, missing_attr):
+                    if missing_attr not in new_attrs and get_sibling_attribute_tag_of_type(doc, attribute_tag, missing_attr) is None:
                         # Only consider attribute missing if it's not in the 'attrs' dict and also not in a separate attribute tag
                         missing_attrs.append(missing_attr)
                 if missing_attrs:
@@ -419,7 +419,7 @@ for xml_file in all_xml_files:
                         new_tag.tail = indent
                         parent_tag.insert(tag_index, new_tag)
                         if missing_attr == 'invisible':
-                            if not get_sibling_attribute_tag_of_type(doc, new_tag, 'states'):
+                            if get_sibling_attribute_tag_of_type(doc, new_tag, 'states') is None:
                                 # Since before Odoo 17 the states and invisible attributes were separate, if a states attribute was
                                 # present in an parent view it would still be combined with the invisible attribute overrides
                                 # in inheriting views. Now that they are combined in 17, if in an inheriting view the invisible
@@ -492,7 +492,7 @@ for xml_file in all_xml_files:
                 tag_index, parent_tag, indent = get_parent_etree_node(doc, attribute_tag_states)
                 tail = attribute_tag_states.tail
                 attribute_tag_invisible = get_sibling_attribute_tag_of_type(doc, attribute_tag_states, 'invisible')
-                if attribute_tag_invisible:
+                if attribute_tag_invisible is not None:
                     # If the states tag is merged into an invisible tag, the tail of the previous tag
                     # has to be updated, since otherwise the tag after the states tag will get indented the
                     # same as the states tag

--- a/replace_attrs.py
+++ b/replace_attrs.py
@@ -400,7 +400,7 @@ for xml_file in all_xml_files:
                     if tag_type == 'field':
                         new_tag = etree.Comment(
                             f"TODO: Result from converting 'attrs' attribute override without options for {missing_attrs} to separate attributes"
-                            f"{indent + (' ' * 5)}Remove redundant tags below for any of those attributes that are not present in the field tag in any of the parent views"
+                            f"{indent + (' ' * 5)}Remove redundant empty tags below for any of those attributes that are not present in the field tag in any of the parent views"
                             f"{indent + (' ' * 5)}If someone later adds one of these attributes in the parent views, they would likely be unaware it's still overridden in this view, resulting in unexpected behaviour, which should be avoided")
                         new_tag.tail = indent
                         parent_tag.insert(tag_index, new_tag)

--- a/testfile.xml
+++ b/testfile.xml
@@ -28,6 +28,8 @@
         <group name="test7" attrs="{'invisible': True}"/>
         <!-- non-field tag with only states -->
         <group name="test8" states="draft,done"/>
+        <!-- test conversion of special characters-->
+        <field name="test9" attrs="{'readonly': [('a', '>', 0), ('b', '&lt;', 0), ('c', '&gt;', 0)]}"/>
         <!-- xpath override of field with both attrs (invisible) and states -->
         <xpath expr="//field[@name='test5']" position="attributes">
             <attribute name="attrs">{

--- a/testfile.xml
+++ b/testfile.xml
@@ -1,44 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <form>
-        <xpath expr="//">
-            <!-- readonly should give: -->
-            <!-- (field1 == 'yes' and field2 != parent.some_field) or (field3 == uid or 'some-string'.lower() in field4.lower()) or 'yes' not in field5 and field6 == 'yes' -->
-            <field string="foo" attrs="{'invisible': True, 'readonly': ['|', '|', '&amp;', ('field1', '=', 'yes'), ('field2', '!=', parent.some_field), '|', ('field3', '=', uid), ('field4', '=ilike', 'some-string'), ('field5', 'not like', 'yes'), ('field6', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c']), ('otherfield', '=?', some_field)], 'column_invisible': 0}" name="name"/>
-        </xpath>
+        <!-- readonly should give: -->
+        <!-- (field1 == 'yes' and field2 != parent.some_field) or (field3 == uid or 'some-string'.lower() in field4.lower()) or 'yes' not in field5 and field6 == 'yes' -->
+        <field string="foo" attrs="{'invisible': True, 'readonly': ['|', '|', '&amp;', ('field1', '=', 'yes'), ('field2', '!=', parent.some_field), '|', ('field3', '=', uid), ('field4', '=ilike', 'some-string'), ('field5', 'not like', 'yes'), ('field6', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c']), ('otherfield', '=?', some_field)], 'column_invisible': 0}" name="name"/>
         <xpath expr="//." position="attributes">
             <attribute name="attrs">{'invisible': True, 'readonly': [('otherfield', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c'])], 'column_invisible': 0}</attribute>
         </xpath>
-        <xpath expr="//field" position="attributes">
+        <xpath expr="//field[@name='test1']" position="attributes">
             <attribute name="attrs">{'invisible': [('some', '=', False), ('other', '!=', False)], 'readonly': [('some', '=', True), ('other', '!=', True)], 'required': [('some', '=', []), ('other', '!=', [])], 'column_invisible': [('some', '=', 'str'), ('other', '!=', 'str')]}</attribute>
             <attribute name="indent_test"/>
         </xpath>
-        <xpath expr="//test_states_simple_case">
-            <field states="draft,done"/>
-        </xpath>
-        <xpath expr="//test_states_attrs_simple_case">
-            <attribute name="states">draft,done</attribute>
-        </xpath>
-        <xpath expr="//test_states_with_invisible_existing">
-            <field states="draft,done" attrs="{'invisible': [('testfield', '=', 'hello world')]}"/>
-        </xpath>
-        <!-- field tag with both attrs and states, with attrs having an invisible attribute -->
-        <field name="test" states="draft,done" attrs="{'invisible': True, 'readonly': True}"/>
-        <!-- field tag with both attrs and states, with attrs not having an invisible attribute -->
-        <field name="test" states="draft,done" attrs="{'readonly': True}"/>
-        <!-- field tag with only attrs, with attrs having an invisible attribute -->
-        <field name="test" attrs="{'invisible': True, 'readonly': True}"/>
-        <!-- field tag with only attrs, with attrs not having an invisible attribute -->
-        <field name="test" attrs="{'readonly': True}"/>
+        <!-- field tag with both attrs (invisible, readonly) and states -->
+        <field name="test1" states="draft,done" attrs="{'invisible': True, 'readonly': True}"/>
+        <!-- field tag with both attrs (readonly, required) and states, with a double required attribute -->
+        <field required="1" name="test2" states="draft,done" attrs="{'readonly': True, 'required': [('otherfield', '=', 'yes')]}"/>
+        <!-- field tag with only attrs (invisible, readonly)-->
+        <field name="test3" attrs="{'invisible': True, 'readonly': True}"/>
+        <!-- field tag with only attrs (readonly) -->
+        <field name="test4" attrs="{'readonly': True}"/>
         <!-- field tag with only states -->
-        <field name="test" states="draft,done"/>
-        <!-- non-field tag with both attrs and states -->
-        <group name="test" states="draft,done" attrs="{'invisible': True}"/>
+        <field name="test5" states="draft,done"/>
+        <!-- non-field tag with both attrs (invisible) and states -->
+        <group name="test6" states="draft,done" attrs="{'invisible': True}"/>
         <!-- non-field tag with only attrs -->
-        <group name="test" attrs="{'invisible': True}"/>
+        <group name="test7" attrs="{'invisible': True}"/>
         <!-- non-field tag with only states -->
-        <group name="test" states="draft,done"/>
-        <xpath expr="//test_states_attrs_with_invisible_existing" position="attributes">
+        <group name="test8" states="draft,done"/>
+        <!-- xpath override of field with both attrs (invisible) and states -->
+        <xpath expr="//field[@name='test5']" position="attributes">
             <attribute name="attrs">{
             'invisible': [
                 '|',
@@ -52,57 +42,51 @@
             }</attribute>
             <attribute name="states">draft,done</attribute>
         </xpath>
-        <!-- xpath override of field with both attrs and states -->
-        <xpath expr="//field[@name='test']">
-            <attribute name="indent_test"/>
-            <attribute name="attrs">{'invisible': True}</attribute>
+        <!-- xpath override of field with both attrs (required, invisible) and states and double required attribute -->
+        <xpath expr="//field[@name='test6']">
+            <attribute name="attrs">{'required': True, 'invisible': [('testfield', '=', 'hello world')]}</attribute>
             <attribute name="states">draft,done</attribute>
+            <attribute name="required">1</attribute>
         </xpath>
-        <!-- xpath override of field with only attrs -->
-        <xpath expr="//field[@name='test']">
-            <attribute name="indent_test"/>
+        <!-- xpath override of field with only attrs (invisible) -->
+        <xpath expr="//field[@name='test7']">
             <attribute name="attrs">{'invisible': True}</attribute>
         </xpath>
         <!-- xpath override of field with only states -->
-        <xpath expr="//field[@name='test']">
-            <attribute name="indent_test"/>
-            <attribute name="attrs">{'invisible': True}</attribute>
+        <xpath expr="//field[@name='test8']">
+            <attribute name="states">draft,done</attribute>
         </xpath>
-        <!-- xpath override of field with empty attrs, and states -->
-        <xpath expr="//field[@name='test']">
-            <attribute name="indent_test"/>
+        <!-- xpath override of field with empty attrs and non-empty states -->
+        <xpath expr="//field[@name='test9']">
             <attribute name="attrs"></attribute>
             <attribute name="states">draft,done</attribute>
         </xpath>
-        <!-- xpath override of field with attrs and empty states -->
-        <xpath expr="//field[@name='test']">
+        <!-- xpath override of field with non-empty attrs (required, invisible) and empty states -->
+        <xpath expr="//field[@name='test10']">
             <attribute name="indent_test"/>
             <attribute name="attrs">{'required': True, 'invisible': True}</attribute>
             <attribute name="states"></attribute>
         </xpath>
-        <!-- xpath override of field with empty attrs and states -->
-        <xpath expr="//field[@name='test']">
-            <attribute name="indent_test"/>
+        <!-- xpath override of field with empty attrs and empty states -->
+        <xpath expr="//field[@name='test11']">
             <attribute name="attrs"></attribute>
             <attribute name="states"></attribute>
         </xpath>
-        <!-- xpath override of non-field with both attrs and states -->
-        <xpath expr="//sheet/group[@name='test']">
-            <attribute name="indent_test"/>
+        <!-- xpath override of non-field with both attrs (invisible) and states -->
+        <xpath expr="//sheet/group[@name='test12']">
             <attribute name="attrs">{'invisible': True}</attribute>
             <attribute name="states">draft,done</attribute>
         </xpath>
-        <!-- xpath override of non-field with only attrs -->
-        <xpath expr="//sheet/group[@name='test']">
-            <attribute name="indent_test"/>
+        <!-- xpath override of non-field with only attrs (invisible) -->
+        <xpath expr="//sheet/group[@name='test13']">
             <attribute name="attrs">{'invisible': True}</attribute>
         </xpath>
         <!-- xpath override of non-field with only states -->
-        <xpath expr="//sheet/group[@name='test']">
-            <attribute name="indent_test"/>
-            <attribute name="attrs">{'invisible': True}</attribute>
+        <xpath expr="//sheet/group[@name='test14']">
+            <attribute name="states">draft,done</attribute>
         </xpath>
-        <field name="test" attrs="{
+        <!-- field tag with only attrs (invisible) -->
+        <field name="test9" attrs="{
             'invisible': [
                 '|',
                 '|',
@@ -113,7 +97,8 @@
                 ('test4', 'in', [%(testmodule.test_xml_id)d, %(testmodule.test_xml_id_2)d])
             ]
         }"/>
-        <group name="test" attrs="{'invisible': True}"/>
+        <!-- non-field tag with only attrs (invisible) -->
+        <group name="test10" attrs="{'invisible': True}"/>
         <!-- Case given by odoo, single '|' with states - can cause bug while should be accepted -->
         <button name="action_open_action_coupon_program" attrs="{'invisible': ['|', ('allow_modification', '=', False)]}" context="{'enable_add_temporary': 1}" class="btn btn-secondary" string="Actions" type="object" states="draft,sent,sale"/>
     </form>

--- a/testfile.xml
+++ b/testfile.xml
@@ -7,6 +7,7 @@
         <xpath expr="//." position="attributes">
             <attribute name="attrs">{'invisible': True, 'readonly': [('otherfield', '=', 'yes')], 'required': [('field', 'in', ['a', 'b', 'c'])], 'column_invisible': 0}</attribute>
         </xpath>
+        <!-- all leafs should evaluate to '[not] <some|other>' -->
         <xpath expr="//field[@name='test1']" position="attributes">
             <attribute name="attrs">{'invisible': [('some', '=', False), ('other', '!=', False)], 'readonly': [('some', '=', True), ('other', '!=', True)], 'required': [('some', '=', []), ('other', '!=', [])], 'column_invisible': [('some', '=', 'str'), ('other', '!=', 'str')]}</attribute>
             <attribute name="indent_test"/>

--- a/testfile.xml
+++ b/testfile.xml
@@ -68,6 +68,24 @@
             <attribute name="indent_test"/>
             <attribute name="attrs">{'invisible': True}</attribute>
         </xpath>
+        <!-- xpath override of field with empty attrs, and states -->
+        <xpath expr="//field[@name='test']">
+            <attribute name="indent_test"/>
+            <attribute name="attrs"></attribute>
+            <attribute name="states">draft,done</attribute>
+        </xpath>
+        <!-- xpath override of field with attrs and empty states -->
+        <xpath expr="//field[@name='test']">
+            <attribute name="indent_test"/>
+            <attribute name="attrs">{'required': True, 'invisible': True}</attribute>
+            <attribute name="states"></attribute>
+        </xpath>
+        <!-- xpath override of field with empty attrs and states -->
+        <xpath expr="//field[@name='test']">
+            <attribute name="indent_test"/>
+            <attribute name="attrs"></attribute>
+            <attribute name="states"></attribute>
+        </xpath>
         <!-- xpath override of non-field with both attrs and states -->
         <xpath expr="//sheet/group[@name='test']">
             <attribute name="indent_test"/>


### PR DESCRIPTION
- Fixed scenario's with empty values for 'attrs' or 'states' attribute tags
- Now properly combines attributes if they exist both as a separate attribute on the tag as well as in the 'attrs' dict
- Fixed a problem where the code would not properly check for existing tags, resulting in some behaviour concerning invisible and states attributes not working correctly
- Adds warning in readme to first convert invisible to column_invisible on tree fields, before running the script